### PR TITLE
fix extraneous slash in github repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can install the package from Github.
 
 ```R
 # install.packages("devtools")
-devtools::install_github("pommedeterresautee/FastRText/")
+devtools::install_github("pommedeterresautee/FastRText")
 ```
 
 API


### PR DESCRIPTION
Hello @pommedeterresautee,

There is a small error in the installation section of the README (an extraneous slash in the github repo name)

```R
> devtools::install_github("pommedeterresautee/FastRText/")
Error in parse_git_repo(repo) : 
  Invalid git repo: pommedeterresautee/FastRText/
```

Vincent